### PR TITLE
Add strict mode to eliminate build error

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+'use strict'
+
 process.env.VUE_ENV = 'server'
 
 const fs = require('fs')


### PR DESCRIPTION
Without this, `npm start` will simply yield an error, at least on my machine.

```
~/w/g/vue-ssr-demo (master) $ npm start                                                                                                               Tue Jun 28 18:00:52 SGT 2016

> vue-ssr-demo@ start /Users/an/www/github/vue-ssr-demo
> node server

/Users/an/www/github/vue-ssr-demo/server.js:68
    let firstChunk = true
    ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
```